### PR TITLE
add aud and scope validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+Release v1.0.4 (2019-07-22)
+===========================
+### Added
+1. Add audience and scope validation
+
+Release v1.0.3 (2019-04-23)
+===========================
+### Fixed
+1. Fixed misconfiguration during permission validation
+
 Release v1.0.2 (2019-03-11)
 ===========================
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -92,6 +92,18 @@ permissionResource["{userId}"] = "example"
 client.ValidatePermission(claims, iam.Permission{Resource:"NAMESPACE:{namespace}:USER:{userId}", Action:4}, permissionResource)
 ```
 
+### Validating Audience and Scope
+
+Validate audience and scope from token owner with those owned by client
+
+```go
+_ = client.ValidateAudienceScope(claims *JWTClaims, scope string) error
+```
+
+**Note**
+
+Required client access token to get client information (client base URI)
+
 ### Health check
 
 Whenever the IAM service went unhealthy, the client will know by detecting if any of the automated refresh goroutines has error.

--- a/client.go
+++ b/client.go
@@ -79,4 +79,7 @@ type Client interface {
 
 	// HealthCheck lets caller know the health of the IAM client
 	HealthCheck() bool
+
+	// ValidateAudienceScope validate audience and scope of user access token
+	ValidateAudienceScope(claims *JWTClaims, scope string) error
 }

--- a/mockclient.go
+++ b/mockclient.go
@@ -142,3 +142,16 @@ func (client *MockClient) HasBan(claims *JWTClaims, banType string) bool {
 func (client *MockClient) HealthCheck() bool {
 	return client.Healthy
 }
+
+// ValidateAudienceScope gets user anonymous status on access token
+func (client *MockClient) ValidateAudienceScope(claims *JWTClaims, scope string) error {
+	if scope == "" {
+		return errors.New("scope isn't valid")
+	}
+
+	if len(claims.Audience) == 0 {
+		return errors.New("audience isn't valid")
+	}
+
+	return nil
+}

--- a/models.go
+++ b/models.go
@@ -133,6 +133,9 @@ type JWTClaims struct {
 	Permissions  []Permission `json:"permissions"`
 	Bans         []JWTBan     `json:"bans"`
 	JusticeFlags int          `json:"jflgs"`
+	Scope        string       `json:"scope"`
+	Country      string       `json:"country"`
+	ClientID     string       `json:"client_id"`
 	jwt.Claims
 }
 


### PR DESCRIPTION
Add audience and scope validation
 - Token Audience will be compared with Client Base URI
 - Token Scope will be compared with client scope (currently defined in service level)
Please help me to review : @thoriqsatriya @banukusuma @rjjatson @desniaak @purbopanambang @rafi-isakh