### PR TITLE
No audience checking if no `aud` field present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Release v1.1.0 (2019-07-28)
+===========================
+### Added
+1. No checking if no `aud` field found in the token.
+2. Write unit tests for making sure `ValidateAudience` works as expected.
+
 Release v1.0.6 (2019-07-25)
 ===========================
 ### Changed

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ client.ValidatePermission(claims, iam.Permission{Resource:"NAMESPACE:{namespace}
 
 ### Validating Audience
 
-Validate audience from token owner with client baseURI
+Validate audience from the token owner with client's base URI
 
 ```go
 _ = client.ValidateAudience(claims *JWTClaims) error

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,7 @@ github.com/willf/bitset v1.1.10 h1:NotGKqX0KwQ72NUzqrjZq5ipPNDQex9lo3WpaS8L2sc=
 github.com/willf/bitset v1.1.10/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=
 golang.org/x/crypto v0.0.0-20190228161510-8dd112bcdc25 h1:jsG6UpNLt9iAsb0S2AGW28DveNzzgmbXR+ENoPjUeIU=
 golang.org/x/crypto v0.0.0-20190228161510-8dd112bcdc25/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90PveolxSbWFaJdECFbxSq0Mqo2M=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=


### PR DESCRIPTION
Additional explanation
1. Standardize the test case name so it follows the current Justice IAM service standard.
2. Add HTTP client mock for mocking HTTP call in the tests.