### PR TITLE
SOCP-583 fix json tag in JWTBan

### DIFF
--- a/models.go
+++ b/models.go
@@ -160,6 +160,6 @@ type UserRevocationListRecord struct {
 
 // JWTBan holds information about ban record in JWT
 type JWTBan struct {
-	Ban     string    `json:"ban"`
-	EndDate time.Time `json:"end_date"`
+	Ban     string    `json:"Ban"`
+	EndDate time.Time `json:"EndDate"`
 }


### PR DESCRIPTION
SDK cannot parse ban value because of the difference of json format