### PR TITLE
fix(permission): fix wildcard permission checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+Release v1.2.0 (2020-09-08)
+===========================
+### Changed
+1. When the granted permission ends with wildcard, check if the wildcard
+   only applies to matches any namspace and user, or the wildcard should
+   match any resources after the namespace and user
+
 Release v1.1.6 (2020-03-10)
 ===========================
 ### Fixed

--- a/defaultclient_test.go
+++ b/defaultclient_test.go
@@ -451,6 +451,21 @@ func Test_DefaultClientValidatePermission(t *testing.T) {
 		{
 			requiredResource: "NAMESPACE:foo:USER:888:PROFILE:birthday",
 			grantedResource:  "NAMESPACE:foo:USER:*",
+			expectedResult:   false,
+		},
+		{
+			requiredResource: "NAMESPACE:foo:USER:888:PROFILE:birthday",
+			grantedResource:  "NAMESPACE:foo:USER:*:*",
+			expectedResult:   true,
+		},
+		{
+			requiredResource: "NAMESPACE:foo:USER:888:PROFILE:birthday",
+			grantedResource:  "*",
+			expectedResult:   true,
+		},
+		{
+			requiredResource: "NAMESPACE:foo:USER:888:PROFILE:birthday",
+			grantedResource:  "NAMESPACE:foo:*",
 			expectedResult:   true,
 		},
 		{

--- a/permission.go
+++ b/permission.go
@@ -30,6 +30,11 @@ import (
 	"github.com/pkg/errors"
 )
 
+const (
+	resourceNamespace = "NAMESPACE"
+	resourceUser      = "USER"
+)
+
 func (client *DefaultClient) permissionAllowed(grantedPermissions []Permission, requiredPermission Permission) bool {
 	for _, grantedPermission := range grantedPermissions {
 		grantedAction := grantedPermission.Action
@@ -87,7 +92,20 @@ func (client *DefaultClient) resourceAllowed(accessPermissionResource string, re
 	}
 
 	if accessPermResSectionLen < requiredPermResSectionLen {
-		return accessPermResSections[accessPermResSectionLen-1] == "*"
+		if accessPermResSections[accessPermResSectionLen-1] == "*" {
+			if accessPermResSectionLen < 2 {
+				return true
+			}
+
+			segment := accessPermResSections[accessPermResSectionLen-2]
+			if segment == resourceNamespace || segment == resourceUser {
+				return false
+			}
+
+			return true
+		}
+
+		return false
 	}
 
 	for i := requiredPermResSectionLen; i < accessPermResSectionLen; i++ {


### PR DESCRIPTION
When the granted permission ends with wildcard, check if the wildcard
only applies to matches any namspace and user, or the wildcard should
match any resources after the namespace and user

BREAKING CHANGE: Yes

Closes CORE-890