### PR TITLE
JLT-191 support mock access token

### DIFF
--- a/defaultclient_test.go
+++ b/defaultclient_test.go
@@ -78,6 +78,7 @@ type tokenUserData struct {
 	DisplayName    string
 	PlatformID     string
 	PlatformUserID string
+	ClientID       string
 	Roles          []string
 	NamespaceRoles []NamespaceRole `json:"namespace_roles"`
 	Permissions    []Permission
@@ -1217,6 +1218,7 @@ func generateClaims(t *testing.T, userData *tokenUserData) *JWTClaims {
 		NamespaceRoles: userData.NamespaceRoles,
 		Permissions:    userData.Permissions,
 		JusticeFlags:   userData.JusticeFlags,
+		ClientID:       userData.ClientID,
 		Claims: jwt.Claims{
 			Subject:  userData.UserID,
 			IssuedAt: jwt.NewNumericDate(tNow),

--- a/mockclient.go
+++ b/mockclient.go
@@ -15,6 +15,8 @@
 package iam
 
 import (
+	"fmt"
+
 	"github.com/AccelByte/go-jose/jwt"
 )
 
@@ -23,6 +25,7 @@ const (
 	MockUnauthorized = "unauthorized"
 	MockForbidden    = "forbidden"
 	MockAudience     = "http://example.com"
+	MockSecret       = "mocksecret"
 )
 
 // MockClient define mock oauth client config
@@ -68,6 +71,15 @@ func (client *MockClient) ValidateAndParseClaims(accessToken string, opts ...Opt
 	claims := &JWTClaims{
 		Claims:    jwt.Claims{Subject: accessToken},
 		Namespace: "MOCK",
+	}
+
+	// extract mock access token
+	jwe, err := jwt.ParseSigned(accessToken)
+	if err == nil {
+		err = jwe.Claims([]byte(MockSecret), &claims)
+		if err != nil {
+			log(fmt.Sprintf("unable to claim mock access token. error: %v", err))
+		}
 	}
 
 	claims.Audience = append(claims.Audience, MockAudience)

--- a/mockclient_test.go
+++ b/mockclient_test.go
@@ -1,0 +1,131 @@
+// Copyright 2021 AccelByte Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package iam
+
+import (
+	"testing"
+
+	jose "github.com/AccelByte/go-jose"
+	"github.com/AccelByte/go-jose/jwt"
+	"github.com/AccelByte/go-restful-plugins/v3/pkg/jaeger"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	testMockClient *MockClient
+	mockSigner     jose.Signer
+)
+
+func init() {
+	jaeger.InitGlobalTracer(jaegerAgentHost, "", "test", "")
+
+	var err error
+
+	mockSigner, err = jose.NewSigner(
+		jose.SigningKey{
+			Algorithm: jose.HS256,
+			Key:       []byte(MockSecret),
+		},
+		(&jose.SignerOptions{}).WithType("JWT"))
+	if err != nil {
+		panic(err)
+	}
+}
+
+func Test_MockClientValidateAndParseClaims(t *testing.T) {
+	t.Parallel()
+
+	payload := &tokenUserData{
+		Namespace: "Accelbyte",
+		UserID:    "e9b1ed0c1a3d473cd970abc845b51d3a",
+		ClientID:  "ea192a6c74404de4a105f0c4882325ce",
+	}
+
+	claims := generateClaims(t, payload)
+
+	accessToken, err := jwt.Signed(mockSigner).Claims(claims).CompactSerialize()
+	if err != nil {
+		panic(err)
+	}
+
+	claims, errValidateAndParseClaims := testMockClient.ValidateAndParseClaims(accessToken)
+
+	assert.Nil(t, errValidateAndParseClaims, "access token is invalid")
+	assert.NotNil(t, claims, "claims should not nil")
+	assert.Equal(t, payload.Namespace, claims.Namespace, "namespace should be equal")
+	assert.Equal(t, payload.UserID, claims.Subject, "userID should be equal")
+	assert.Equal(t, payload.ClientID, claims.ClientID, "clientID should be equal")
+
+	if len(claims.Audience) == 1 {
+		assert.Equal(t, MockAudience, claims.Audience[0], "audience should be equal")
+	} else {
+		assert.Fail(t, "audience size isn't match")
+	}
+
+	if len(claims.Roles) == 1 {
+		assert.Equal(t, MockForbidden, claims.Roles[0], "roles should be equal")
+	} else {
+		assert.Fail(t, "roles size isn't match")
+	}
+
+	if len(claims.Permissions) == 1 {
+		assert.Equal(t, "MOCK", claims.Permissions[0].Resource, "permissions resource should be equal")
+		assert.Equal(t, ActionCreate|ActionRead|ActionUpdate|ActionDelete, claims.Permissions[0].Action,
+			"permissions action should be equal")
+	} else {
+		assert.Fail(t, "permissions size isn't match")
+	}
+}
+
+func Test_MockClientValidateAndParseClaims_EmptyPayload(t *testing.T) {
+	t.Parallel()
+
+	payload := &tokenUserData{}
+
+	claims := generateClaims(t, payload)
+
+	accessToken, err := jwt.Signed(mockSigner).Claims(claims).CompactSerialize()
+	if err != nil {
+		panic(err)
+	}
+
+	claims, errValidateAndParseClaims := testMockClient.ValidateAndParseClaims(accessToken)
+
+	assert.Nil(t, errValidateAndParseClaims, "access token is invalid")
+	assert.NotNil(t, claims, "claims should not nil")
+	assert.Equal(t, payload.Namespace, claims.Namespace, "namespace should be equal")
+	assert.Equal(t, accessToken, claims.Subject, "subject should be equal with access token")
+	assert.Equal(t, payload.ClientID, claims.ClientID, "clientID should be equal")
+
+	if len(claims.Audience) == 1 {
+		assert.Equal(t, MockAudience, claims.Audience[0], "audience should be equal")
+	} else {
+		assert.Fail(t, "audience size isn't match")
+	}
+
+	if len(claims.Roles) == 1 {
+		assert.Equal(t, MockForbidden, claims.Roles[0], "roles should be equal")
+	} else {
+		assert.Fail(t, "roles size isn't match")
+	}
+
+	if len(claims.Permissions) == 1 {
+		assert.Equal(t, "MOCK", claims.Permissions[0].Resource, "permissions resource should be equal")
+		assert.Equal(t, ActionCreate|ActionRead|ActionUpdate|ActionDelete, claims.Permissions[0].Action,
+			"permissions action should be equal")
+	} else {
+		assert.Fail(t, "permissions size isn't match")
+	}
+}


### PR DESCRIPTION
IAM Go SDK support mock access token in order to run load testing in parallel and not dependent to IAM