### PR TITLE
chore: Tidy up logging error stack trace

### DIFF
--- a/defaultclient.go
+++ b/defaultclient.go
@@ -194,7 +194,7 @@ func (client *DefaultClient) ClientTokenGrant(opts ...Option) error {
 	if err != nil {
 		jaeger.TraceError(span, err)
 
-		return logAndReturnErr(
+		return logWithStackTraceAndReturnErr(
 			errors.WithMessage(err,
 				"ClientTokenGrant: unable to do token grant"))
 	}
@@ -234,7 +234,7 @@ func (client *DefaultClient) StartLocalValidation(opts ...Option) error {
 		jaeger.TraceError(span, errors.WithMessage(err,
 			"StartLocalValidation: unable to get JWKS"))
 
-		return logAndReturnErr(
+		return logWithStackTraceAndReturnErr(
 			errors.WithMessage(err,
 				"StartLocalValidation: unable to get JWKS"))
 	}
@@ -244,7 +244,7 @@ func (client *DefaultClient) StartLocalValidation(opts ...Option) error {
 		jaeger.TraceError(span, errors.WithMessage(err,
 			"StartLocalValidation: unable to get revocation list"))
 
-		return logAndReturnErr(
+		return logWithStackTraceAndReturnErr(
 			errors.WithMessage(err,
 				"StartLocalValidation: unable to get revocation list"))
 	}
@@ -415,7 +415,7 @@ func (client *DefaultClient) ValidatePermission(claims *JWTClaims,
 				b,
 			)
 		if err != nil {
-			err = logAndReturnErr(
+			err = logWithStackTraceAndReturnErr(
 				errors.WithMessage(err,
 					"ValidatePermission: unable to get role perms"))
 			jaeger.TraceError(span, err)
@@ -464,7 +464,7 @@ func (client *DefaultClient) ValidatePermission(claims *JWTClaims,
 				b,
 			)
 		if err != nil {
-			err = logAndReturnErr(
+			err = logWithStackTraceAndReturnErr(
 				errors.WithMessage(err,
 					"ValidatePermission: unable to get role perms"))
 			jaeger.TraceError(span, err)
@@ -575,13 +575,13 @@ func (client *DefaultClient) HealthCheck(opts ...Option) bool {
 	defer jaeger.Finish(span)
 
 	if client.jwksRefreshError != nil {
-		logErr(client.jwksRefreshError,
+		logErrWithStackTrace(client.jwksRefreshError,
 			"HealthCheck: error in JWKs refresh")
 		return false
 	}
 
 	if client.revocationListRefreshError != nil {
-		logErr(client.revocationListRefreshError,
+		logErrWithStackTrace(client.revocationListRefreshError,
 			"HealthCheck: error in revocation list refresh")
 		return false
 	}
@@ -589,7 +589,7 @@ func (client *DefaultClient) HealthCheck(opts ...Option) bool {
 	isTokenRefreshActive := client.tokenRefreshActive.Load()
 	tokenRefreshError := client.tokenRefreshError.Load()
 	if isTokenRefreshActive && tokenRefreshError != nil {
-		logErr(
+		logErrWithStackTrace(
 			tokenRefreshError,
 			"HealthCheck: error in token refresh",
 		)
@@ -720,7 +720,7 @@ func (client *DefaultClient) GetRolePermissions(roleID string, opts ...Option) (
 			b,
 		)
 	if err != nil {
-		err = logAndReturnErr(
+		err = logWithStackTraceAndReturnErr(
 			errors.WithMessage(err,
 				"GetRolePermissions: unable to get role perms"))
 		jaeger.TraceError(span, err)
@@ -785,7 +785,7 @@ func (client *DefaultClient) fetchClientInformation(namespace string, clientID s
 				reqSpan := jaeger.StartChildSpan(span, "HTTP Request: "+req.Method+" "+req.URL.Path)
 				defer jaeger.Finish(reqSpan)
 				jErr := jaeger.InjectSpanIntoRequest(reqSpan, req)
-				logErr(jErr)
+				logErrWithStackTrace(jErr)
 
 				resp, e := client.httpClient.Do(req)
 				if e != nil {

--- a/defaultclient.go
+++ b/defaultclient.go
@@ -575,13 +575,13 @@ func (client *DefaultClient) HealthCheck(opts ...Option) bool {
 	defer jaeger.Finish(span)
 
 	if client.jwksRefreshError != nil {
-		logErrWithStackTrace(client.jwksRefreshError,
+		logWithStackTraceErr(client.jwksRefreshError,
 			"HealthCheck: error in JWKs refresh")
 		return false
 	}
 
 	if client.revocationListRefreshError != nil {
-		logErrWithStackTrace(client.revocationListRefreshError,
+		logWithStackTraceErr(client.revocationListRefreshError,
 			"HealthCheck: error in revocation list refresh")
 		return false
 	}
@@ -589,7 +589,7 @@ func (client *DefaultClient) HealthCheck(opts ...Option) bool {
 	isTokenRefreshActive := client.tokenRefreshActive.Load()
 	tokenRefreshError := client.tokenRefreshError.Load()
 	if isTokenRefreshActive && tokenRefreshError != nil {
-		logErrWithStackTrace(
+		logWithStackTraceErr(
 			tokenRefreshError,
 			"HealthCheck: error in token refresh",
 		)
@@ -785,7 +785,7 @@ func (client *DefaultClient) fetchClientInformation(namespace string, clientID s
 				reqSpan := jaeger.StartChildSpan(span, "HTTP Request: "+req.Method+" "+req.URL.Path)
 				defer jaeger.Finish(reqSpan)
 				jErr := jaeger.InjectSpanIntoRequest(reqSpan, req)
-				logErrWithStackTrace(jErr)
+				logWithStackTraceErr(jErr)
 
 				resp, e := client.httpClient.Do(req)
 				if e != nil {

--- a/jwks.go
+++ b/jwks.go
@@ -101,7 +101,7 @@ func (client *DefaultClient) getJWKS(rootSpan opentracing.Span) error {
 				reqSpan := jaeger.StartChildSpan(span, "HTTP Request: "+req.Method+" "+req.URL.Path)
 				defer jaeger.Finish(reqSpan)
 				jErr := jaeger.InjectSpanIntoRequest(reqSpan, req)
-				logErr(jErr)
+				logErrWithStackTrace(jErr)
 
 				resp, e := client.httpClient.Do(req)
 				if e != nil {

--- a/jwks.go
+++ b/jwks.go
@@ -101,7 +101,7 @@ func (client *DefaultClient) getJWKS(rootSpan opentracing.Span) error {
 				reqSpan := jaeger.StartChildSpan(span, "HTTP Request: "+req.Method+" "+req.URL.Path)
 				defer jaeger.Finish(reqSpan)
 				jErr := jaeger.InjectSpanIntoRequest(reqSpan, req)
-				logErrWithStackTrace(jErr)
+				logWithStackTraceErr(jErr)
 
 				resp, e := client.httpClient.Do(req)
 				if e != nil {

--- a/log.go
+++ b/log.go
@@ -25,7 +25,21 @@ func log(s ...interface{}) {
 	fmt.Println(s...)
 }
 
-func logErr(err error, s ...interface{}) {
+func logErrWithStackTrace(err error, s ...interface{}) {
+	doLogErr(err, true, s)
+}
+
+func logAndReturnErr(err error, s ...interface{}) error {
+	doLogErr(err, false, s)
+	return err
+}
+
+func logWithStackTraceAndReturnErr(err error, s ...interface{}) error {
+	doLogErr(err, true, s)
+	return err
+}
+
+func doLogErr(err error, printStackTrace bool, s ...interface{}) {
 	if !debug.Load() {
 		return
 	}
@@ -36,11 +50,9 @@ func logErr(err error, s ...interface{}) {
 
 	fmt.Print("[IAM-Go-SDK] ")
 	fmt.Println(s...)
-	fmt.Printf("%+v\n", err)
-}
-
-// nolint: unparam
-func logAndReturnErr(err error, s ...interface{}) error {
-	logErr(err, s...)
-	return err
+	if printStackTrace {
+		fmt.Printf("%+v\n", err)
+	} else {
+		fmt.Printf("%+v\n", err.Error())
+	}
 }

--- a/log.go
+++ b/log.go
@@ -25,7 +25,7 @@ func log(s ...interface{}) {
 	fmt.Println(s...)
 }
 
-func logErrWithStackTrace(err error, s ...interface{}) {
+func logWithStackTraceErr(err error, s ...interface{}) {
 	doLogErr(err, true, s)
 }
 

--- a/permission.go
+++ b/permission.go
@@ -152,7 +152,7 @@ func (client *DefaultClient) getRolePermission(roleID string, rootSpan opentraci
 				reqSpan := jaeger.StartChildSpan(span, "HTTP Request: "+req.Method+" "+req.URL.Path)
 				defer jaeger.Finish(reqSpan)
 				jErr := jaeger.InjectSpanIntoRequest(reqSpan, req)
-				logErrWithStackTrace(jErr)
+				logWithStackTraceErr(jErr)
 
 				resp, e := client.httpClient.Do(req)
 				if e != nil {

--- a/permission.go
+++ b/permission.go
@@ -152,7 +152,7 @@ func (client *DefaultClient) getRolePermission(roleID string, rootSpan opentraci
 				reqSpan := jaeger.StartChildSpan(span, "HTTP Request: "+req.Method+" "+req.URL.Path)
 				defer jaeger.Finish(reqSpan)
 				jErr := jaeger.InjectSpanIntoRequest(reqSpan, req)
-				logErr(jErr)
+				logErrWithStackTrace(jErr)
 
 				resp, e := client.httpClient.Do(req)
 				if e != nil {

--- a/revocation.go
+++ b/revocation.go
@@ -92,7 +92,7 @@ func (client *DefaultClient) getRevocationList(rootSpan opentracing.Span) error 
 				reqSpan := jaeger.StartChildSpan(span, "client.getRevocationList.Retry")
 				defer jaeger.Finish(reqSpan)
 				jErr := jaeger.InjectSpanIntoRequest(reqSpan, req)
-				logErrWithStackTrace(jErr)
+				logWithStackTraceErr(jErr)
 
 				resp, e := client.httpClient.Do(req)
 

--- a/revocation.go
+++ b/revocation.go
@@ -92,7 +92,7 @@ func (client *DefaultClient) getRevocationList(rootSpan opentracing.Span) error 
 				reqSpan := jaeger.StartChildSpan(span, "client.getRevocationList.Retry")
 				defer jaeger.Finish(reqSpan)
 				jErr := jaeger.InjectSpanIntoRequest(reqSpan, req)
-				logErr(jErr)
+				logErrWithStackTrace(jErr)
 
 				resp, e := client.httpClient.Do(req)
 

--- a/token.go
+++ b/token.go
@@ -58,7 +58,7 @@ func (client *DefaultClient) validateAccessToken(accessToken string, rootSpan op
 				reqSpan := jaeger.StartChildSpan(span, "HTTP Request: "+req.Method+" "+req.URL.Path)
 				defer jaeger.Finish(reqSpan)
 				jErr := jaeger.InjectSpanIntoRequest(reqSpan, req)
-				logErrWithStackTrace(jErr)
+				logWithStackTraceErr(jErr)
 
 				resp, e := client.httpClient.Do(req)
 				if e != nil {
@@ -238,7 +238,7 @@ func (client *DefaultClient) clientTokenGrant(rootSpan opentracing.Span) (time.D
 				reqSpan := jaeger.StartChildSpan(span, "HTTP Request: "+req.Method+" "+req.URL.Path)
 				defer jaeger.Finish(reqSpan)
 				jErr := jaeger.InjectSpanIntoRequest(reqSpan, req)
-				logErrWithStackTrace(jErr)
+				logWithStackTraceErr(jErr)
 
 				resp, e := client.httpClient.Do(req)
 				if e != nil {

--- a/token.go
+++ b/token.go
@@ -58,7 +58,7 @@ func (client *DefaultClient) validateAccessToken(accessToken string, rootSpan op
 				reqSpan := jaeger.StartChildSpan(span, "HTTP Request: "+req.Method+" "+req.URL.Path)
 				defer jaeger.Finish(reqSpan)
 				jErr := jaeger.InjectSpanIntoRequest(reqSpan, req)
-				logErr(jErr)
+				logErrWithStackTrace(jErr)
 
 				resp, e := client.httpClient.Do(req)
 				if e != nil {
@@ -238,7 +238,7 @@ func (client *DefaultClient) clientTokenGrant(rootSpan opentracing.Span) (time.D
 				reqSpan := jaeger.StartChildSpan(span, "HTTP Request: "+req.Method+" "+req.URL.Path)
 				defer jaeger.Finish(reqSpan)
 				jErr := jaeger.InjectSpanIntoRequest(reqSpan, req)
-				logErr(jErr)
+				logErrWithStackTrace(jErr)
 
 				resp, e := client.httpClient.Do(req)
 				if e != nil {


### PR DESCRIPTION
For some operation, print stack trace not suitable, but better to show 1 line error message
e.g. Invalid token, User revoked, Token revoked, Claims invalid, etc.

