### PR TITLE
fix: Change permission resource/action to upper case

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,7 @@ github.com/AccelByte/go-jose v2.1.4+incompatible h1:jn3BJ0HZAUskWJ042CJGgFXDAwhT
 github.com/AccelByte/go-jose v2.1.4+incompatible/go.mod h1:X9vkgMrcPILJ7qhUruCaKHnslOhBTTpsC5DjiFpmmSc=
 github.com/AccelByte/go-restful-plugins/v3 v3.2.1 h1:My/jP+wxJM+0adg1vJBja11/+tMc26KB3n+RaGuMkuo=
 github.com/AccelByte/go-restful-plugins/v3 v3.2.1/go.mod h1:XkhxnbfR/0z5lj2xI2SVbSuF5PhCi39xVYmVODwFf7k=
+github.com/AccelByte/iam-go-sdk v1.1.2 h1:LhmzKaXAsedI4BVLVmYtDTIsDcc+d51vP2CZ9aVowkI=
 github.com/AccelByte/iam-go-sdk v1.1.2/go.mod h1:M1Eplqpph/Msxm7XKgZRI+cYBCCChFdgPiVdKYupwq8=
 github.com/AccelByte/public-source-ip v1.0.0/go.mod h1:L7zIgt3UaXkGH7NoKFCbxPdWZOVwn+d6uW/5yYRXtnQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=

--- a/mockclient_test.go
+++ b/mockclient_test.go
@@ -67,6 +67,9 @@ func Test_MockClientValidateAndParseClaims(t *testing.T) {
 	assert.Equal(t, payload.Namespace, claims.Namespace, "namespace should be equal")
 	assert.Equal(t, payload.UserID, claims.Subject, "userID should be equal")
 	assert.Equal(t, payload.ClientID, claims.ClientID, "clientID should be equal")
+	assert.ElementsMatch(t, claims.Permissions, []Permission{
+		{Resource: "MOCK", Action: ActionCreate | ActionRead | ActionUpdate | ActionDelete},
+	})
 
 	if len(claims.Audience) == 1 {
 		assert.Equal(t, MockAudience, claims.Audience[0], "audience should be equal")

--- a/models.go
+++ b/models.go
@@ -52,8 +52,8 @@ type TokenResponse struct {
 }
 
 type Permission struct {
-	Resource        string   `json:"resource"`
-	Action          int      `json:"action"`
+	Resource        string   `json:"Resource"`
+	Action          int      `json:"Action"`
 	ScheduledAction int      `json:"schedAction,omitempty"`
 	CronSchedule    string   `json:"schedCron,omitempty"`
 	RangeSchedule   []string `json:"schedRange,omitempty"`


### PR DESCRIPTION
Address issue where permissions field is empty.
Changed the json field tags in the permissions to lower-case to be compatible with the access token as provided by IAM.  