### PR TITLE
fix: Refresh JWKS have a very short possibility to make the keys cache empty

### DIFF
--- a/defaultclient.go
+++ b/defaultclient.go
@@ -168,17 +168,13 @@ func NewDefaultClient(config *Config) *DefaultClient {
 	return client
 }
 
-func (client *DefaultClient) setKeysSafe(values map[string]*rsa.PublicKey) {
-	client.keysMutex.Lock()
-	defer client.keysMutex.Unlock()
-
-	client.keys = values
-}
-
 func (client *DefaultClient) setKeySafe(key string, value *rsa.PublicKey) {
 	client.keysMutex.Lock()
 	defer client.keysMutex.Unlock()
 
+	if len(client.keys) == 0 {
+		client.keys = make(map[string]*rsa.PublicKey)
+	}
 	client.keys[key] = value
 }
 

--- a/jwks.go
+++ b/jwks.go
@@ -147,8 +147,6 @@ func (client *DefaultClient) getJWKS(rootSpan opentracing.Span) error {
 		return errors.Wrap(err, "getJWKS: unable to unmarshal response body")
 	}
 
-	client.setKeysSafe(make(map[string]*rsa.PublicKey))
-
 	for i := range jwks.Keys {
 		jwk := &jwks.Keys[i]
 


### PR DESCRIPTION
[This code](https://github.com/AccelByte/iam-go-sdk/blob/master/jwks.go#L150-L161) have possibility to make cache empty in a very short time.
If ValidateAndParseClaims called during that time, it will failed got public key doesn't exist

![image](https://github.com/AccelByte/iam-go-sdk/assets/17809418/81a16327-1549-41c7-aa1e-56a863b26e6b)

Example error in service when validating access token:
```
error="ValidateAndParseClaims: unable to validate JWT: validateJWT: invalid key: getPublicKey: public key doesn't exist"
```